### PR TITLE
Remove remaining uses of __import decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,12 @@ Nullam quis ante. Aenean viverra rhoncus pede.
 Pellentesque commodo eros a enim. Nam eget dui.
 
 Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Vestibulum turpis sem, aliquet eget, lobortis pellentesque, rutrum eu, nisl.
+
+
+### Editing file on 2022-10-06_10-56-08
+
+Integer id tempus leo, consectetur pretium lorem. Sed auctor interdum elit luctus imperdiet. Proin vitae mi et leo ornare placerat. Ut consequat malesuada diam. Aenean quis sem eget nulla congue lobortis. Fusce sed justo vestibulum, sollicitudin ipsum a, scelerisque est. Fusce non metus a nisl molestie vestibulum sed eu justo.
+Fusce viverra porta arcu, a rhoncus purus dignissim non. Vestibulum malesuada, augue interdum pretium vestibulum, orci lorem accumsan ligula, at ullamcorper est mauris eget odio. Praesent fermentum hendrerit elit in aliquet. Proin sed justo id justo sodales euismod sed in nisi. Morbi condimentum ligula et ante consequat elementum. Proin sagittis lobortis nibh, eu convallis eros fringilla et. Sed condimentum dignissim libero, bibendum dictum mauris scelerisque vitae. Donec elementum urna tellus, sit amet volutpat magna elementum eu. Nunc varius at tellus nec cursus. Etiam non tellus dignissim, pulvinar tellus sed, dapibus tellus. Pellentesque mollis ullamcorper lectus vitae aliquet. Sed venenatis diam lacus. Pellentesque lacinia, risus quis hendrerit pharetra, odio turpis euismod eros, maximus tempor mi quam et ipsum. Suspendisse at ex quam. Maecenas suscipit iaculis mi, eget convallis felis finibus nec. Maecenas vulputate urna eu risus vestibulum finibus.
+Duis quis elit tincidunt neque tincidunt pellentesque. Sed auctor, nibh eu finibus imperdiet, justo nisi luctus mauris, quis vestibulum ante libero id lectus. Mauris tincidunt eget eros ut feugiat. Interdum et malesuada fames ac ante ipsum primis in faucibus. Morbi consequat ligula et risus interdum, ac placerat sem efficitur. Nunc blandit turpis eu ultrices consequat. Quisque fringilla odio arcu, id tempus ligula efficitur in. Sed non iaculis metus. Fusce sit amet lacus nec dui egestas placerat a vitae risus. Pellentesque vitae tellus aliquet, luctus odio vitae, pharetra sapien. Nullam id mi a lorem lobortis fringilla euismod vitae odio. Fusce non libero in mi blandit accumsan.
+
+


### PR DESCRIPTION
It looks they are not necessary anymore since #17411.
`__asyncify_state__import` and `__asyncify_data__import` were added
after that when #15893 landed, and `__c_longjmp_import` was a typo in
the first place (there are only one `_` instead of two `_`s before
`import`) so it was likely not detected when other uses were removed.

Signed-off-by: peterjuma <30427827+peterjuma@users.noreply.github.com>
